### PR TITLE
speed-up fix

### DIFF
--- a/R/slide.R
+++ b/R/slide.R
@@ -42,22 +42,22 @@ slide <- function(data, Var, GroupVar = NULL, NewVar = NULL, slideBy = -1)
   if (!isTRUE(TestExist)){
     stop(paste(Var, "was not found in the data frame."))
   }
-
+  
   VarVect <- data[, Var]
-
+  
   if (is.null(NewVar)){
     NewVar <- paste0(Var, slideBy)
   }
-
+  
   # Create lags/leads
   if (is.null(GroupVar)){
     data[, NewVar] <- shift(VarVect = VarVect, shiftBy = slideBy)
   }
   else if (!is.null(GroupVar)){
-    data <- eval(parse(text = paste0("ddply(data, GroupVar, transform, NewVarX = shift(", Var, ",", slideBy, "))")))
-    data <- rename(data, c("NewVarX" = NewVar)) 
+    vars <- eval(parse(text = paste0("ddply(data[, c(GroupVar, Var)], GroupVar, transform, NewVarX = shift(", Var, ",", slideBy, "))")))
+    data[, NewVar] <- vars$NewVarX
   }
-
+  
   return(data)
 }
 


### PR DESCRIPTION
This passes only necessary variables to ddply, which considerably speeds up the function on large data frames. Here are some tests on a [training set](http://www.qog.pol.gu.se/) of 14,137 rows and 728 variables.

```
> dim(QOG)
[1] 14137   731
> # lag test
> system.time(QOG$oil_lag2 <- lagpanel(QOG$ross_oil_price, QOG$ccode, QOG$year, 2))
   user  system elapsed 
  0.220   0.010   0.231 
> system.time(QOG <- slide(QOG, "ross_oil_price", "ccode", "oil_lag2", slideBy = -2))
   user  system elapsed 
 20.783   3.359  24.299 
> system.time(QOG <- slide2(QOG, "ross_oil_price", "ccode", "oil_lag2", slideBy = -2))
   user  system elapsed 
  0.189   0.016   0.207 
> 
> # lead test
> system.time(QOG <- slide(QOG, "wdi_gdpc", "ccode", "oil_lead5", slideBy = 5))
   user  system elapsed 
 20.265   3.458  23.768 
> system.time(QOG <- slide2(QOG, "wdi_gdpc", "ccode", "oil_lead5", slideBy = 5))
   user  system elapsed 
  0.187   0.014   0.201 
```
